### PR TITLE
port should only be calculated once

### DIFF
--- a/start.go
+++ b/start.go
@@ -83,7 +83,7 @@ func runStart(cmd *Command, args []string) {
 			port := flagPort + (idx * 100)
 			ps := NewProcess(proc.Command, env)
 			processes[proc.Name] = ps
-			ps.Env["PORT"] = strconv.Itoa(flagPort + (idx * 1000))
+			ps.Env["PORT"] = strconv.Itoa(port)
 			ps.Root = filepath.Dir(flagProcfile)
 			ps.Stdin = nil
 			ps.Stdout = of.CreateOutlet(proc.Name, idx, false)


### PR DESCRIPTION
Starting two process groups using the "PORT" env variable results in ports separated by 1000, although the forego log messages report the expect ports:

```
forego start
forego | starting web on port 5000
forego | starting api on port 5100
web    | 2013/10/23 09:30:57 listening localhost:5000
api    | 2013/10/23 09:30:57 listening localhost:6000
```

Expected behavior is that the ports increment by 100.
