### PR TITLE
Enable no colorization of output.

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -31,17 +31,17 @@ func (p *Process) Signal(signal syscall.Signal) {
 	}
 }
 
-func ShutdownProcesses(of *OutletFactory) {
+func ShutdownProcesses(of *OutletFactory, noColor bool) {
 	shutdown_mutex.Lock()
-	of.SystemOutput("shutting down")
+	of.SystemOutput("shutting down", noColor)
 	for name, ps := range processes {
-		of.SystemOutput(fmt.Sprintf("sending SIGTERM to %s", name))
+		of.SystemOutput(fmt.Sprintf("sending SIGTERM to %s", name), noColor)
 		ps.Signal(syscall.SIGTERM)
 	}
 	go func() {
 		time.Sleep(shutdownGraceTime)
 		for name, ps := range processes {
-			of.SystemOutput(fmt.Sprintf("sending SIGKILL to %s", name))
+			of.SystemOutput(fmt.Sprintf("sending SIGKILL to %s", name), noColor)
 			ps.Signal(syscall.SIGKILL)
 		}
 	}()

--- a/outlet.go
+++ b/outlet.go
@@ -20,6 +20,7 @@ type Outlet struct {
 	Color   ct.Color
 	IsError bool
 	Factory *OutletFactory
+	NoColor bool
 }
 
 var mx sync.Mutex
@@ -45,9 +46,11 @@ func (o *Outlet) Write(b []byte) (num int, err error) {
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	for scanner.Scan() {
 		formatter := fmt.Sprintf("%%-%ds | ", o.Factory.Padding)
-		ct.ChangeColor(o.Color, true, ct.None, false)
+		if !o.NoColor {
+			ct.ChangeColor(o.Color, true, ct.None, false)
+		}
 		fmt.Printf(formatter, o.Name)
-		if o.IsError {
+		if o.IsError && !o.NoColor {
 			ct.ChangeColor(ct.Red, true, ct.None, true)
 		} else {
 			ct.ResetColor()
@@ -63,13 +66,15 @@ func ProcessOutput(w io.Writer, str string) {
 	w.Write([]byte(str))
 }
 
-func (of *OutletFactory) CreateOutlet(name string, index int, isError bool) *Outlet {
-	of.Outlets[name] = &Outlet{name, colors[index%len(colors)], isError, of}
+func (of *OutletFactory) CreateOutlet(name string, index int, isError bool, noColor bool) *Outlet {
+	of.Outlets[name] = &Outlet{name, colors[index%len(colors)], isError, of, noColor}
 	return of.Outlets[name]
 }
 
-func (of *OutletFactory) SystemOutput(str string) {
-	ct.ChangeColor(ct.White, true, ct.None, false)
+func (of *OutletFactory) SystemOutput(str string, noColor bool) {
+	if !noColor {
+		ct.ChangeColor(ct.White, true, ct.None, false)
+	}
 	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
 	fmt.Printf(formatter, "forego")
 	ct.ResetColor()


### PR DESCRIPTION
Colors aren't ideal if you are doing something like syslog.

This allows you to pass -n to disable them
