### PR TITLE
Fix bug calculating a group's port

### DIFF
--- a/start.go
+++ b/start.go
@@ -83,7 +83,7 @@ func runStart(cmd *Command, args []string) {
 			port := flagPort + (idx * 100)
 			ps := NewProcess(proc.Command, env)
 			processes[proc.Name] = ps
-			ps.Env["PORT"] = strconv.Itoa(flagPort + (idx * 1000))
+			ps.Env["PORT"] = strconv.Itoa(port)
 			ps.Root = filepath.Dir(flagProcfile)
 			ps.Stdin = nil
 			ps.Stdout = of.CreateOutlet(proc.Name, idx, false)


### PR DESCRIPTION
In the original foreman, an increase of 100 defined the number of the first process of the next group, hence, a two type Procfile uses ports 5000 and 5100. Forego was correctly printing this expected numbers but line 86 was recalculating this port number again with a distance of 1000 not a hundred. The result was that I was seeing my second type of process listening on port 6000, not the expected 5100.

Thanks for creating this, it saves a lot of headaches and time for us!
