### PR TITLE
Check ps.Start() error

### DIFF
--- a/start.go
+++ b/start.go
@@ -126,7 +126,12 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 
 	finished := make(chan struct{}) // closed on process exit
 
-	ps.Start()
+	err = ps.Start()
+	if err != nil {
+		f.teardown.Fall()
+		of.SystemOutput(fmt.Sprint("Failed to start ", procName, ": ", err))
+		return
+	}
 
 	f.wg.Add(1)
 	go func() {


### PR DESCRIPTION
This doesn't usually happen unless the shell is broken or unavailable.

It's nice though to have a program which shows an error message rather than
quitting silently. The test to see if this is working is to modify the shell
in `unix.go` to something which doesn't exist.
