### PR TITLE
Support multiple named procs in `forego start`

### DIFF
--- a/procfile.go
+++ b/procfile.go
@@ -30,13 +30,14 @@ func ReadProcfile(filename string) (*Procfile, error) {
 	return parseProcfile(fd)
 }
 
-func (pf *Procfile) HasProcess(name string) (exists bool) {
-	for _, entry := range pf.Entries {
+func (pf *Procfile) GetProcess(name string) (entry ProcfileEntry, ok bool) {
+	for _, entry = range pf.Entries {
 		if name == entry.Name {
-			return true
+			ok = true
+			return
 		}
 	}
-	return false
+	return
 }
 
 func (pf *Procfile) LongestProcessName(concurrency map[string]int) (longest int) {


### PR DESCRIPTION
Found a need for this.

nsq consists of `nsqd`, `nsqlookupd` and `nsqadmin`. `nsqadmin` only needs to run
on nodes which are used to control all of the other nodes, whereas `nsqd` and
`nsqadmin` need to run everywhere.
