### PR TITLE
Show run help with no args

### DIFF
--- a/run.go
+++ b/run.go
@@ -24,6 +24,10 @@ func init() {
 }
 
 func runRun(cmd *Command, args []string) {
+	if len(args) < 1 {
+		cmd.printUsage()
+		os.Exit(1)
+	}
 	workDir, err := os.Getwd()
 	if err != nil {
 		handleError(err)


### PR DESCRIPTION
If you don't to provide any argument, you only get **ERROR: exit status 1**.  Most probably you will not get to merge this code in order to have consistency with the behavior of the rest of the commands, but I thought this gives you more info about the error itself.
