### PR TITLE
Read port from env

### DIFF
--- a/start.go
+++ b/start.go
@@ -13,6 +13,7 @@ import (
 )
 
 const shutdownGraceTime = 3 * time.Second
+const defaultPort = 5000
 
 var flagPort int
 var flagConcurrency string
@@ -36,7 +37,7 @@ Examples:
 func init() {
 	cmdStart.Flag.StringVar(&flagProcfile, "f", "Procfile", "procfile")
 	cmdStart.Flag.StringVar(&flagEnv, "e", "", "env")
-	cmdStart.Flag.IntVar(&flagPort, "p", 5000, "port")
+	cmdStart.Flag.IntVar(&flagPort, "p", defaultPort, "port")
 	cmdStart.Flag.StringVar(&flagConcurrency, "c", "", "concurrency")
 	cmdStart.Flag.BoolVar(&flagRestart, "r", false, "restart")
 }
@@ -97,8 +98,22 @@ func (f *Forego) monitorInterrupt() {
 	}
 }
 
+func basePort(env Env) (int, error) {
+	if flagPort != defaultPort {
+		return flagPort, nil
+	} else if env["PORT"] != "" {
+		return strconv.Atoi(env["PORT"])
+	}
+	return defaultPort, nil
+}
+
 func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of *OutletFactory) {
-	port := flagPort + (idx * 100)
+	port, err := basePort(env)
+	if err != nil {
+		panic(err)
+	}
+
+	port = port + (idx * 100)
 
 	const interactive = false
 	workDir := filepath.Dir(flagProcfile)

--- a/start_test.go
+++ b/start_test.go
@@ -106,3 +106,30 @@ func TestParseConcurrencyFlagNoValue(t *testing.T) {
 	}
 
 }
+
+func TestPortFromEnv(t *testing.T) {
+	env := make(Env)
+	port, err := basePort(env)
+	if err != nil {
+		t.Fatalf("Can not get base port: %s", err)
+	}
+	if port != 5000 {
+		t.Fatal("Base port should be 5000")
+	}
+
+	env["PORT"] = "6000"
+	port, err = basePort(env)
+	if err != nil {
+		t.Fatalf("Can not get base port: %s", err)
+	}
+	if port != 6000 {
+		t.Fatal("Base port should be 6000")
+	}
+
+	env["PORT"] = "forego"
+	port, err = basePort(env)
+	if err == nil {
+		t.Fatalf("Port 'forego' should fail: %s", err)
+	}
+
+}


### PR DESCRIPTION
Allow the port to be set on the .env file to avoid using the port flag
every time.