### PR TITLE
Support multiple environment flags

### DIFF
--- a/env.go
+++ b/env.go
@@ -11,6 +11,33 @@ var envEntryRegexp = regexp.MustCompile("^([A-Za-z_0-9]+)=(.*)$")
 
 type Env map[string]string
 
+func loadEnvs(files []string) (Env, error) {
+	if len(files) == 0 {
+		env, err := ReadEnv(fullPath(".env"))
+		if err != nil {
+			return nil, err
+		} else {
+			return env, nil
+		}
+	}
+
+	// Handle multiple environment files
+	env := make(Env)
+	for _, file := range files {
+		tmpEnv, err := ReadEnv(file)
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Merge the file I just read into the env.
+		for k, v := range tmpEnv {
+			env[k] = v
+		}
+	}
+	return env, nil
+}
+
 func ReadEnv(filename string) (Env, error) {
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return make(Env), nil

--- a/env.go
+++ b/env.go
@@ -4,12 +4,29 @@ import (
 	"fmt"
 	"github.com/subosito/gotenv"
 	"os"
+	"path/filepath"
 	"regexp"
 )
 
 var envEntryRegexp = regexp.MustCompile("^([A-Za-z_0-9]+)=(.*)$")
 
 type Env map[string]string
+
+type envFiles []string
+
+func (e *envFiles) String() string {
+	return fmt.Sprintf("%s", *e)
+}
+
+func (e *envFiles) Set(value string) error {
+	*e = append(*e, fullPath(value))
+	return nil
+}
+
+func fullPath(file string) string {
+	root := filepath.Dir(".")
+	return filepath.Join(root, file)
+}
 
 func loadEnvs(files []string) (Env, error) {
 	if len(files) == 0 {

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestMultipleEnvironmentFiles(t *testing.T) {
+	envs := []string{"fixtures/envs/.env1", "fixtures/envs/.env2"}
+	env, err := loadEnvs(envs)
+
+	if err != nil {
+		t.Fatalf("Could not read environments: %s", err)
+	}
+
+	if env["env1"] == "" {
+		t.Fatalf("$env1 should be present and is not")
+	}
+
+	if env["env2"] == "" {
+		t.Fatalf("$env2 should be present and is not")
+	}
+}

--- a/fixtures/envs/.env1
+++ b/fixtures/envs/.env1
@@ -1,0 +1,1 @@
+env1=present

--- a/fixtures/envs/.env2
+++ b/fixtures/envs/.env2
@@ -1,0 +1,1 @@
+env2=present

--- a/run.go
+++ b/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -19,8 +18,10 @@ Examples:
 `,
 }
 
+var runEnvs envFiles
+
 func init() {
-	cmdRun.Flag.StringVar(&flagEnv, "e", ".env", "env")
+	cmdRun.Flag.Var(&runEnvs, "e", "env")
 }
 
 func runRun(cmd *Command, args []string) {
@@ -32,11 +33,8 @@ func runRun(cmd *Command, args []string) {
 	if err != nil {
 		handleError(err)
 	}
-	if flagEnv == "" {
-		flagEnv = filepath.Join(workDir, ".env")
-	}
 
-	env, err := ReadEnv(flagEnv)
+	env, err := loadEnvs(runEnvs)
 	handleError(err)
 
 	const interactive = true

--- a/start.go
+++ b/start.go
@@ -14,17 +14,6 @@ import (
 
 const shutdownGraceTime = 3 * time.Second
 
-type envFiles []string
-
-func (e *envFiles) String() string {
-	return fmt.Sprintf("%s", *e)
-}
-
-func (e *envFiles) Set(value string) error {
-	*e = append(*e, fullPath(value))
-	return nil
-}
-
 var flagPort int
 var flagConcurrency string
 var flagRestart bool
@@ -189,11 +178,6 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 			}
 		}
 	}()
-}
-
-func fullPath(file string) string {
-	root := filepath.Dir(".")
-	return filepath.Join(root, file)
 }
 
 func runStart(cmd *Command, args []string) {

--- a/start.go
+++ b/start.go
@@ -192,35 +192,8 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 }
 
 func fullPath(file string) string {
-	root := filepath.Dir(flagProcfile)
+	root := filepath.Dir(".")
 	return filepath.Join(root, file)
-}
-
-func parseEnvironment(files []string) (Env, error) {
-	if len(files) == 0 {
-		env, err := ReadEnv(fullPath(".env"))
-		if err != nil {
-			return nil, err
-		} else {
-			return env, nil
-		}
-	}
-
-	// Handle multiple environment files
-	env := make(Env)
-	for _, file := range files {
-		tmpEnv, err := ReadEnv(file)
-
-		if err != nil {
-			return nil, err
-		}
-
-		// Merge the file I just read into the env.
-		for k, v := range tmpEnv {
-			env[k] = v
-		}
-	}
-	return env, nil
 }
 
 func runStart(cmd *Command, args []string) {
@@ -230,7 +203,7 @@ func runStart(cmd *Command, args []string) {
 	concurrency, err := parseConcurrency(flagConcurrency)
 	handleError(err)
 
-	env, err := parseEnvironment(envs)
+	env, err := loadEnvs(envs)
 	handleError(err)
 
 	of := NewOutletFactory()

--- a/start_test.go
+++ b/start_test.go
@@ -106,3 +106,20 @@ func TestParseConcurrencyFlagNoValue(t *testing.T) {
 	}
 
 }
+
+func TestMultipleEnvironmentFiles(t *testing.T) {
+	envs := []string{"fixtures/envs/.env1", "fixtures/envs/.env2"}
+	env, err := parseEnvironment(envs)
+
+	if err != nil {
+		t.Fatalf("Could not read environments: %s", err)
+	}
+
+	if env["env1"] == "" {
+		t.Fatalf("$env1 should be present and is not")
+	}
+
+	if env["env2"] == "" {
+		t.Fatalf("$env2 should be present and is not")
+	}
+}

--- a/start_test.go
+++ b/start_test.go
@@ -106,20 +106,3 @@ func TestParseConcurrencyFlagNoValue(t *testing.T) {
 	}
 
 }
-
-func TestMultipleEnvironmentFiles(t *testing.T) {
-	envs := []string{"fixtures/envs/.env1", "fixtures/envs/.env2"}
-	env, err := parseEnvironment(envs)
-
-	if err != nil {
-		t.Fatalf("Could not read environments: %s", err)
-	}
-
-	if env["env1"] == "" {
-		t.Fatalf("$env1 should be present and is not")
-	}
-
-	if env["env2"] == "" {
-		t.Fatalf("$env2 should be present and is not")
-	}
-}


### PR DESCRIPTION
This adds support for multiple environment files via multiple `-e` flags.

For this I had to create a custom `Flag` and extracted the logic to read the env to a function so I could write the tests easier.

This fixes #13