### PR TITLE
Read PORT from the environment

### DIFF
--- a/outlet.go
+++ b/outlet.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"github.com/ddollar/forego/Godeps/_workspace/src/github.com/daviddengcn/go-colortext"
 	"io"
 	"os"
 	"sync"
-	"bytes"
 )
 
 type OutletFactory struct {

--- a/start.go
+++ b/start.go
@@ -104,6 +104,8 @@ func basePort(env Env) (int, error) {
 		return flagPort, nil
 	} else if env["PORT"] != "" {
 		return strconv.Atoi(env["PORT"])
+	} else if os.Getenv("PORT") != "" {
+		return strconv.Atoi(os.Getenv("PORT"))
 	}
 	return defaultPort, nil
 }

--- a/start_test.go
+++ b/start_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestParseConcurrencyFlagEmpty(t *testing.T) {
 	c, err := parseConcurrency("")
@@ -115,6 +118,15 @@ func TestPortFromEnv(t *testing.T) {
 	}
 	if port != 5000 {
 		t.Fatal("Base port should be 5000")
+	}
+
+	os.Setenv("PORT", "4000")
+	port, err = basePort(env)
+	if err != nil {
+		t.Fatal("Can not get port: %s", err)
+	}
+	if port != 4000 {
+		t.Fatal("Base port should be 4000")
 	}
 
 	env["PORT"] = "6000"


### PR DESCRIPTION
Read the `PORT` from the system environment if it's present. This is related to #44 and will make the port read order this:

1. `-p` flag.
2. `PORT` in the `.env` file
3. `PORT` environment variable
4. 5000 as default port