### PR TITLE
Changing Procfile parser to work on Windows

### DIFF
--- a/procfile.go
+++ b/procfile.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	_ "github.com/ddollar/forego/Godeps/_workspace/src/github.com/kr/pretty"
-	"io"
 	"math"
 	"os"
 	"regexp"
+
+	_ "github.com/ddollar/forego/Godeps/_workspace/src/github.com/kr/pretty"
 )
 
 var procfileEntryRegexp = regexp.MustCompile("^([A-Za-z0-9_]+):\\s*(.+)$")
@@ -54,19 +52,4 @@ func (pf *Procfile) LongestProcessName(concurrency map[string]int) (longest int)
 		}
 	}
 	return
-}
-
-func parseProcfile(r io.Reader) (*Procfile, error) {
-	pf := new(Procfile)
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		parts := procfileEntryRegexp.FindStringSubmatch(scanner.Text())
-		if len(parts) > 0 {
-			pf.Entries = append(pf.Entries, ProcfileEntry{parts[1], parts[2]})
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Reading Procfile: %s", err)
-	}
-	return pf, nil
 }

--- a/procfile_others.go
+++ b/procfile_others.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+func parseProcfile(r io.Reader) (*Procfile, error) {
+	pf := new(Procfile)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		parts := procfileEntryRegexp.FindStringSubmatch(scanner.Text())
+		if len(parts) > 0 {
+			pf.Entries = append(pf.Entries, ProcfileEntry{parts[1], parts[2]})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Reading Procfile: %s", err)
+	}
+	return pf, nil
+}

--- a/procfile_windows.go
+++ b/procfile_windows.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+)
+
+func parseProcfile(r io.Reader) (*Procfile, error) {
+	pf := new(Procfile)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := envNixToWin(scanner.Bytes())
+		parts := procfileEntryRegexp.FindStringSubmatch(line)
+		if len(parts) > 0 {
+			pf.Entries = append(pf.Entries, ProcfileEntry{parts[1], parts[2]})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Reading Procfile: %s", err)
+	}
+	return pf, nil
+}
+
+func envNixToWin(line []byte) string {
+	nr := regexp.MustCompile("\\${?(\\w+)}?")
+	out := nr.ReplaceAll(line, []byte("%$1%"))
+	return string(out)
+}


### PR DESCRIPTION
This is in response to issue #34. Nothing fancy, just a simple regex replacement for nix `$VARIABLE` or `${VARIABLE}` to Windows equivalent `%VARIABLE%` on parse. Tested on my local machines (Arch and Windows) without issue.

It won't handle `$THIS$KIND` of case well, or a dozen other edge cases, but I didn't want to fall down the rabbit hole of trying to handle every single use case and writing a full-on lexer.