### PR TITLE
Allow local config with .forego

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/ddollar/forego/Godeps/_workspace/src/github.com/subosito/gotenv"
+	"os"
+)
+
+type Config map[string]string
+
+func ReadConfig(filename string) (Config, error) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return make(Config), nil
+	}
+	fd, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	config := make(Config)
+	for key, val := range gotenv.Parse(fd) {
+		config[key] = val
+	}
+	return config, nil
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestReadOptionFile(t *testing.T) {
+	config_file := "./fixtures/options/.forego"
+	_, err := ReadConfig(config_file)
+	if err != nil {
+		t.Fatalf("Could not read config file: %s", err)
+	}
+}

--- a/fixtures/configs/.forego
+++ b/fixtures/configs/.forego
@@ -1,0 +1,3 @@
+procfile: Procfile.dev
+concurrency: foo=2,bar=3
+port: 15000

--- a/start.go
+++ b/start.go
@@ -41,6 +41,25 @@ func init() {
 	cmdStart.Flag.IntVar(&flagPort, "p", defaultPort, "port")
 	cmdStart.Flag.StringVar(&flagConcurrency, "c", "", "concurrency")
 	cmdStart.Flag.BoolVar(&flagRestart, "r", false, "restart")
+	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency)
+	handleError(err)
+}
+
+func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string) error {
+	config, err := ReadConfig(config_path)
+
+	if config["procfile"] != "" {
+		*flagProcfile = config["procfile"]
+	} else {
+		*flagProcfile = "Procfile"
+	}
+	if config["port"] != "" {
+		*flagPort, err = strconv.Atoi(config["port"])
+	} else {
+		*flagPort = defaultPort
+	}
+	*flagConcurrency = config["concurrency"]
+	return err
 }
 
 func parseConcurrency(value string) (map[string]int, error) {

--- a/start_test.go
+++ b/start_test.go
@@ -145,3 +145,26 @@ func TestPortFromEnv(t *testing.T) {
 	}
 
 }
+
+func TestConfigBeOverrideByForegoFile(t *testing.T) {
+	var procfile = "Profile"
+	var port = 5000
+	var concurrency string = "web=2"
+	err := readConfigFile("./fixtures/configs/.forego", &procfile, &port, &concurrency)
+
+	if err != nil {
+		t.Fatalf("Cannot set default values from forego config file")
+	}
+
+	if procfile != "Procfile.dev" {
+		t.Fatal("Procfile should be Procfile.dev")
+	}
+
+	if port != 15000 {
+		t.Fatal("port should be 15000, got %d", port)
+	}
+
+	if concurrency != "foo=2,bar=3" {
+		t.Fatal("concurrency should be 'foo=2,bar=3', got %s", concurrency)
+	}
+}


### PR DESCRIPTION
See #32
`gotenv` can read simple yaml file so we don't need to use a read yaml parse.
The value in forego file will be set as default value, if we set flag or env value, it will override the value in forego file.
