### PR TITLE
Allow hyphen for proc name

### DIFF
--- a/procfile.go
+++ b/procfile.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 )
 
-var procfileEntryRegexp = regexp.MustCompile("^([A-Za-z0-9_]+):\\s*(.+)$")
+var procfileEntryRegexp = regexp.MustCompile("^([A-Za-z0-9_-]+):\\s*(.+)$")
 
 type ProcfileEntry struct {
 	Name    string


### PR DESCRIPTION
My Procfile is below.

```
web: bundle exec unicorn -p 3000 -c ./config/unicorn/development.rb
worker: bundle exec sidekiq -C config/sidekiq.yml
browser-sync: browser-sync start --config bs-config.js
```

without this patch, 'browser-sync' doesn't run. (foreman can run them three all.)