### PR TITLE
use exec to prevent spawn unneeded subprocess

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -16,7 +16,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 		shellArgument = "-ic"
 	}
 	profile := filepath.Join(root, ".profile")
-	shellCommand := fmt.Sprintf("source \"%s\" 2>/dev/null; %s", profile, command)
+	shellCommand := fmt.Sprintf("source \"%s\" 2>/dev/null; exec %s", profile, command)
 	return []string{"/bin/bash", shellArgument, shellCommand}
 
 }


### PR DESCRIPTION
I believe here we should replace the current process instead of spawn new one. This will enable the command to spawn subprocess and receive `SIGTERM` properly