### PR TITLE
Use bash from current environment

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -17,7 +17,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	}
 	profile := filepath.Join(root, ".profile")
 	shellCommand := fmt.Sprintf("source \"%s\" 2>/dev/null; %s", profile, command)
-	return []string{"/bin/bash", shellArgument, shellCommand}
+	return []string{"bash", shellArgument, shellCommand}
 
 }
 


### PR DESCRIPTION
Not all Unix platforms put their `bash` executable at `/bin/bash`, for example on NixOS it may exist at `/run/current-system/sw/bin/bash`.

Instead of using `/bin/bash`, then, use `bash` alone, and allow the [cmd package to resolve the correct path][cmd] bashed on the user's current environment.

  [cmd]: https://golang.org/pkg/os/exec/#Command

Before:

```
$ forego start
forego  | starting web.1 on port 3000
forego  | Failed to start web.1: fork/exec /bin/bash: no such file or directory
forego  | starting worker.1 on port 3100
forego  | Failed to start worker.1: fork/exec /bin/bash: no such file or directory
```

After:

```
$ forego start
forego  | starting web.1 on port 3000
forego  | starting worker.1 on port 3100
web.1   | [26076] Started
```