### PR TITLE
Fix restart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ sudo: false
 
 language: go
 go:
-  - 1.3.1
+  - 1.6
 
 env:
   global:
     - PATH=$HOME/gopath/bin:$PATH
 
 before_install:
-  - go get code.google.com/p/go.tools/cmd/cover
   - go get github.com/tools/godep
   - godep restore
 

--- a/start.go
+++ b/start.go
@@ -165,7 +165,9 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 
 		// Prevent goroutine from exiting before process has finished.
 		defer func() { <-finished }()
-		defer f.teardown.Fall()
+		if !flagRestart {
+			defer f.teardown.Fall()
+		}
 
 		select {
 		case <-finished:


### PR DESCRIPTION
`forego start -r` is broken since commit 34b39bf589fc727164368695be1aa908972de324. When a process supervised by forego is killed, instead of being restarted, forego stop all processes.