### PR TITLE
Simplify Forego.startProcess

### DIFF
--- a/start.go
+++ b/start.go
@@ -174,9 +174,6 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 		case <-f.teardown.Barrier():
 			// Forego tearing down
 
-			// Prevent goroutine from exiting before process has finished.
-			defer func() { <-finished }()
-
 			if !osHaveSigTerm {
 				of.SystemOutput(fmt.Sprintf("Killing %s", procName))
 				ps.Process.Kill()

--- a/start.go
+++ b/start.go
@@ -163,9 +163,6 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 	go func() {
 		defer f.wg.Done()
 
-		// Prevent goroutine from exiting before process has finished.
-		defer func() { <-finished }()
-
 		select {
 		case <-finished:
 			if flagRestart {
@@ -176,6 +173,9 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 
 		case <-f.teardown.Barrier():
 			// Forego tearing down
+
+			// Prevent goroutine from exiting before process has finished.
+			defer func() { <-finished }()
 
 			if !osHaveSigTerm {
 				of.SystemOutput(fmt.Sprintf("Killing %s", procName))

--- a/start.go
+++ b/start.go
@@ -165,14 +165,13 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 
 		// Prevent goroutine from exiting before process has finished.
 		defer func() { <-finished }()
-		if !flagRestart {
-			defer f.teardown.Fall()
-		}
 
 		select {
 		case <-finished:
 			if flagRestart {
 				f.startProcess(idx, procNum, proc, env, of)
+			} else {
+				f.teardown.Fall()
 			}
 
 		case <-f.teardown.Barrier():

--- a/start.go
+++ b/start.go
@@ -173,7 +173,6 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 		case <-finished:
 			if flagRestart {
 				f.startProcess(idx, procNum, proc, env, of)
-				return
 			}
 
 		case <-f.teardown.Barrier():


### PR DESCRIPTION
The only aim of this set of commits is to simplify Forego.startProcess. It is decomposed in 4 commits just to make the reasoning clear.