### PR TITLE
Add flag to customize shutdown gracetime

### DIFF
--- a/fixtures/configs/.forego
+++ b/fixtures/configs/.forego
@@ -1,3 +1,4 @@
 procfile: Procfile.dev
 concurrency: foo=2,bar=3
 port: 15000
+shutdown_grace_time: 30

--- a/start_test.go
+++ b/start_test.go
@@ -150,7 +150,8 @@ func TestConfigBeOverrideByForegoFile(t *testing.T) {
 	var procfile = "Profile"
 	var port = 5000
 	var concurrency string = "web=2"
-	err := readConfigFile("./fixtures/configs/.forego", &procfile, &port, &concurrency)
+	var gracetime int = 3
+	err := readConfigFile("./fixtures/configs/.forego", &procfile, &port, &concurrency, &gracetime)
 
 	if err != nil {
 		t.Fatalf("Cannot set default values from forego config file")
@@ -166,5 +167,9 @@ func TestConfigBeOverrideByForegoFile(t *testing.T) {
 
 	if concurrency != "foo=2,bar=3" {
 		t.Fatal("concurrency should be 'foo=2,bar=3', got %s", concurrency)
+	}
+
+	if gracetime != 30 {
+		t.Fatal("gracetime should be 3, got %d", gracetime)
 	}
 }


### PR DESCRIPTION
With `foreman` it was possible to customize the timeout, but not with `forego`,
so I added the necessary flag to the `start` command.