### PR TITLE
Fix longest name length

### DIFF
--- a/procfile.go
+++ b/procfile.go
@@ -47,6 +47,9 @@ func (pf *Procfile) LongestProcessName(concurrency map[string]int) (longest int)
 		if c, ok := concurrency[entry.Name]; ok {
 			// Add the number of digits
 			thisLen += int(math.Log10(float64(c))) + 1
+		} else {
+			// The index number after the dot.
+			thisLen += 1
 		}
 		if thisLen > longest {
 			longest = thisLen


### PR DESCRIPTION
Hi @ddollar,
thanks for your work on Forego.

Just an aesthetical issue: there is a wrong alignement when the longest name of processes has length 6.

A Procfile:

```
qwerty: echo 'hi'
```

Output with current version:

```
forego  | starting qwerty.1 on port 5000
qwerty.1 | hi
```

Output applying this commit:

```
forego   | starting qwerty.1 on port 5000
qwerty.1 | hi
```