### PR TITLE
Build with CircleCI v2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.9
+
+    working_directory: /go/src/github.com/nzsmartie/forego
+
+    environment:
+      TEST_RESULTS: /tmp/test-results
+
+    steps:
+      - checkout
+      - run: go get github.com/daviddengcn/go-colortext
+      - run: go get github.com/subosito/gotenv
+
+      # For capturing test results
+      - run: go get github.com/jstemmer/go-junit-report
+      - run: mkdir -p $TEST_RESULTS
+      
+      # specify any bash command here prefixed with `run: `   
+      - run: 
+          name: Run unit tests
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/forego-tests.log > ${TEST_RESULTS}/forego-tests-report.xml" EXIT
+            make test | tee ${TEST_RESULTS}/forego-tests.log
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+        
+      - store_test_results:
+          path: /tmp/test-results
+  release:
+    docker:
+      - image: circleci/golang:1.9
+
+    working_directory: /go/src/github.com/nzsmartie/forego
+
+    steps:
+      - checkout
+      - run: go get github.com/daviddengcn/go-colortext
+      - run: go get github.com/subosito/gotenv
+
+      - run: make release
+
+workflows:
+  version: 2
+  deployment:
+    jobs:
+      - build
+      - release:
+          requires: 
+          - build
+          filters:
+            branches:
+              only: master

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN = forego
-SRC = $(shell ls *.go)
+SRC = $(shell find . -name '*.go' -not -path './vendor/*')
 
 .PHONY: all build clean lint release test
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-test:
-  override:
-    - make test
-
-deployment:
-  master:
-    branch: master
-    commands:
-      - make release


### PR DESCRIPTION
This uses CircleCi's version 2 build configuration.
The goal here was to enable selecting which version of Golang to build against (in this case i've chosen 1.9) and fix #108 as I suspect older versions of go don't build darwin_arm64? 🤷‍♀️ 