### PR TITLE
Fix using concurrency and arg together in start

### DIFF
--- a/start_test.go
+++ b/start_test.go
@@ -123,7 +123,7 @@ func TestPortFromEnv(t *testing.T) {
 	os.Setenv("PORT", "4000")
 	port, err = basePort(env)
 	if err != nil {
-		t.Fatal("Can not get port: %s", err)
+		t.Fatalf("Can not get port: %s", err)
 	}
 	if port != 4000 {
 		t.Fatal("Base port should be 4000")
@@ -162,14 +162,14 @@ func TestConfigBeOverrideByForegoFile(t *testing.T) {
 	}
 
 	if port != 15000 {
-		t.Fatal("port should be 15000, got %d", port)
+		t.Fatalf("port should be 15000, got %d", port)
 	}
 
 	if concurrency != "foo=2,bar=3" {
-		t.Fatal("concurrency should be 'foo=2,bar=3', got %s", concurrency)
+		t.Fatalf("concurrency should be 'foo=2,bar=3', got %s", concurrency)
 	}
 
 	if gracetime != 30 {
-		t.Fatal("gracetime should be 3, got %d", gracetime)
+		t.Fatalf("gracetime should be 3, got %d", gracetime)
 	}
 }


### PR DESCRIPTION
If you ran "forego start" with both arguments and a concurrency flag it would often hang:
    
        forego start -c hello=2 world
    
Secondly, in concurrency mode we didn't check if the process requested actually existed, which could also cause forego to hang. We fix this two bugs by unifying the argument and concurrency flag code paths. In the process, we also extend argument mode to accept multiple processes to launch, so we can now type:
    
        forego start hello world
    
Giving us a slightly nicer interface. If you use both arguments and concurrency flags as in the first example, this will work and even allow you to specify the same process to launch in both lists, with the concurrency value coming from the concurrency list.