### PR TITLE
Update unix.go

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -15,7 +15,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 		shellArgument = "-ic"
 	}
 	shellCommand := fmt.Sprintf("cd \"%s\"; source .profile 2>/dev/null; exec %s", root, command)
-	return []string{"bash", shellArgument, shellCommand}
+	return []string{"sh", shellArgument, shellCommand}
 }
 
 func (p *Process) PlatformSpecificInit() {


### PR DESCRIPTION
Better use `sh` instead of `bash` because the latter is not always available.

That prevents the following situation:

```
forego  | starting api.1 on port 5100
forego  | Failed to start api.1: exec: "bash": executable file not found in $PATH
```

