### PR TITLE
Add NO_COLOR, inject version tag, and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BIN = forego
 SRC = $(shell find . -name '*.go' -not -path './vendor/*')
+VERSION = dev
 
 .PHONY: all build clean lint release test
 
@@ -20,4 +21,4 @@ test: lint build
 	go test -v -race -cover ./...
 
 $(BIN): $(SRC)
-	go build -o $@
+	go build -ldflags "-X main.Version=$(VERSION)" -o $@

--- a/outlet.go
+++ b/outlet.go
@@ -12,7 +12,7 @@ import (
 )
 
 type OutletFactory struct {
-	Padding int
+	LeftFormatter string
 
 	sync.Mutex
 }
@@ -80,8 +80,7 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	if colorize {
 		ct.ChangeColor(leftC, true, ct.None, false)
 	}
-	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
-	fmt.Printf(formatter, left)
+	fmt.Printf(of.LeftFormatter, left)
 
 	if colorize {
 		if isError {

--- a/outlet.go
+++ b/outlet.go
@@ -77,17 +77,21 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	of.Lock()
 	defer of.Unlock()
 
-	ct.ChangeColor(leftC, true, ct.None, false)
+	if colorize {
+		ct.ChangeColor(leftC, true, ct.None, false)
+	}
 	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
 	fmt.Printf(formatter, left)
 
-	if isError {
-		ct.ChangeColor(ct.Red, true, ct.None, true)
-	} else {
-		ct.ResetColor()
+	if colorize {
+		if isError {
+			ct.ChangeColor(rightC, true, ct.None, true)
+		} else {
+			ct.ResetColor()
+		}
 	}
 	fmt.Println(right)
-	if isError {
+	if colorize && isError {
 		ct.ResetColor()
 	}
 }

--- a/start.go
+++ b/start.go
@@ -91,7 +91,7 @@ func init() {
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
-	colorize = terminal.IsTerminal(int(os.Stdout.Fd()))
+	colorize = os.Getenv("NO_COLOR") == "" && terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {

--- a/start.go
+++ b/start.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const defaultPort = 5000
@@ -21,6 +23,7 @@ var flagConcurrency string
 var flagRestart bool
 var flagShutdownGraceTime int
 var envs envFiles
+var colorize bool
 
 var cmdStart = &Command{
 	Run:   runStart,
@@ -88,6 +91,7 @@ func init() {
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
+	colorize = terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {

--- a/start.go
+++ b/start.go
@@ -279,7 +279,7 @@ func runStart(cmd *Command, args []string) {
 	handleError(err)
 
 	of := NewOutletFactory()
-	of.Padding = pf.LongestProcessName(concurrency)
+	of.LeftFormatter = fmt.Sprintf("%%-%ds | ", pf.LongestProcessName(concurrency))
 
 	f := &Forego{
 		outletFactory: of,

--- a/start_test.go
+++ b/start_test.go
@@ -123,7 +123,7 @@ func TestPortFromEnv(t *testing.T) {
 	os.Setenv("PORT", "4000")
 	port, err = basePort(env)
 	if err != nil {
-		t.Fatal("Can not get port: %s", err)
+		t.Fatalf("Can not get port: %s", err)
 	}
 	if port != 4000 {
 		t.Fatal("Base port should be 4000")
@@ -162,14 +162,14 @@ func TestConfigBeOverrideByForegoFile(t *testing.T) {
 	}
 
 	if port != 15000 {
-		t.Fatal("port should be 15000, got %d", port)
+		t.Fatalf("port should be 15000, got %d", port)
 	}
 
 	if concurrency != "foo=2,bar=3" {
-		t.Fatal("concurrency should be 'foo=2,bar=3', got %s", concurrency)
+		t.Fatalf("concurrency should be 'foo=2,bar=3', got %s", concurrency)
 	}
 
 	if gracetime != 30 {
-		t.Fatal("gracetime should be 3, got %d", gracetime)
+		t.Fatalf("gracetime should be 3, got %d", gracetime)
 	}
 }

--- a/unix.go
+++ b/unix.go
@@ -14,7 +14,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"$1\"; . ./.profile 2>/dev/null; exec %s", command)
+	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -e .profile && . ./.profile; exec %s", command)
 	return []string{"/bin/sh", shellArgument, shellCommand, "sh", root}
 }
 

--- a/unix.go
+++ b/unix.go
@@ -14,8 +14,8 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"%s\"; source .profile 2>/dev/null; exec %s", root, command)
-	return []string{"sh", shellArgument, shellCommand}
+	shellCommand := fmt.Sprintf("cd \"%s\"; . ./.profile 2>/dev/null; exec %s", root, command)
+	return []string{"/bin/sh", shellArgument, shellCommand}
 }
 
 func (p *Process) PlatformSpecificInit() {

--- a/unix.go
+++ b/unix.go
@@ -14,7 +14,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -e .profile && . ./.profile; exec %s", command)
+	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -f .profile && . ./.profile; exec %s", command)
 	return []string{"/bin/sh", shellArgument, shellCommand, "sh", root}
 }
 

--- a/unix.go
+++ b/unix.go
@@ -14,8 +14,8 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"%s\"; . ./.profile 2>/dev/null; exec %s", root, command)
-	return []string{"/bin/sh", shellArgument, shellCommand}
+	shellCommand := fmt.Sprintf("cd \"$1\"; . ./.profile 2>/dev/null; exec %s", command)
+	return []string{"/bin/sh", shellArgument, shellCommand, "sh", root}
 }
 
 func (p *Process) PlatformSpecificInit() {


### PR DESCRIPTION
This PR is a rebased version of #122 with a couple more commits added by me. That original PR improves the error handling and adds automatic disabling of color output based on whether stdout is a terminal.

This PR expands on that with a few more commits to:

1. Add injecting a VERSION Makefile variable so you can include the date / commit in the resulting build. Defaults to current value of "dev":

```sh
$ make VERSION="$(date --utc +%Y%m%d-%H%M%S)-$(git show-ref -s -- HEAD)" build
...
$ forego version
20200605-120321-0bdbf9b27cf9da13e246ff1ba90ab5961f4be849
```

2. Checks for a NO_COLOR env variable and, if defined, disables color output regardless of whether we're running in a terminal (per https://no-color.org/)

```sh
$ NO_COLOR=1 forego start
...
```

3. Optimize things a bit by only creating the "left" outlet formatter once. Previously it was being generated for ever line of output but the format itself never changes so it's wasted cycles.

